### PR TITLE
fix(ui): hide form item when prop is undefined

### DIFF
--- a/src/components/datatable/components/SearchFields/index.tsx
+++ b/src/components/datatable/components/SearchFields/index.tsx
@@ -13,7 +13,7 @@ function SearchFields<FormObjectType, RecordType extends object>({
   searchFields = [],
   searchButtonText = ButtonDefaultText.FILTER,
   resetButtonText = ButtonDefaultText.RESET,
-  extraOperationButtons = <></>,
+  extraOperationButtons = undefined,
   loadDataImmediately = true,
   onSearch,
   onBeforeReset,
@@ -101,7 +101,9 @@ function SearchFields<FormObjectType, RecordType extends object>({
       <Form form={searchFormInstance} layout="inline">
         {formFields}
         {searchButtons}
-        <Form.Item>{extraOperationButtons}</Form.Item>
+        {extraOperationButtons && (
+          <Form.Item>{extraOperationButtons}</Form.Item>
+        )}
       </Form>
     </SearchFormWrapper>
   );


### PR DESCRIPTION
1. Remove extra space generated by `<Form.Item />` when prop value is undefined

**Bug**
<img width="784" height="307" alt="Screenshot 2025-07-22 at 10 30 35 PM" src="https://github.com/user-attachments/assets/9d03c954-b813-424f-9044-42c8534137a9" />

**Fix**
<img width="929" height="304" alt="Screenshot 2025-07-22 at 10 32 31 PM" src="https://github.com/user-attachments/assets/5f5d0b02-7e7d-4f0c-9671-f7904a82ebb6" />
